### PR TITLE
Remove name specfication in package config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Elixir wrapper for the Smartsheet API
 
 ## Installation
 
-The package can be installed by adding `smartsheet_api` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `smartsheet` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:smartsheet_api, "~> 0.1.0"}
+    {:smartsheet, "~> 0.1.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Smartsheet.MixProject do
 
   defp package do
     [
-      name: "smartsheet_api",
+      name: "smartsheet",
       licenses: ["MIT License"],
       links: %{"GitHub" => "https://github.com/fast-radius/smartsheet"},
       source_url: "https://github.com/fast-radius/smartsheet"


### PR DESCRIPTION
I thought I could just _name_ it differently than the .app name, as documented [here](https://hex.pm/docs/publish#adding-metadata-to-code-classinlinemixexscode), but i'm having issues with the package being able to find the .app. /shrug I'll just rename it to smartsheet.