### PR TITLE
Small updates

### DIFF
--- a/lib/smartsheet/mock_client/mock_client.ex
+++ b/lib/smartsheet/mock_client/mock_client.ex
@@ -1,22 +1,25 @@
 defmodule Smartsheet.MockClient do
-  def get("/sheets" <> id, _headers, _options) do
-    Smartsheet.MockClient.ResponseFixtures.get_sheet_success(id)
+  def get("/sheets/get_sheet_fail_id", _header, _options) do
+    Smartsheet.MockClient.ResponseFixtures.get_sheet_failure("get_sheet_fail_id")
   end
 
-  def get("/sheets/failed_id", _header, _options) do
-    Smartsheet.MockClient.ResponseFixtures.get_sheet_failure("failed_id")
+  def get("/sheets/" <> id, _headers, _options) do
+    Smartsheet.MockClient.ResponseFixtures.get_sheet_success(id)
   end
 
   def post("/sheets", _attributes, _headers) do
     Smartsheet.MockClient.ResponseFixtures.create_sheet_success()
   end
 
-  def post("/sheets/:id/rows", _attributes, _headers) do
-    Smartsheet.MockClient.ResponseFixtures.add_rows_success()
+  def post("/sheets/:id/rows", rows, _headers) do
+    Smartsheet.MockClient.ResponseFixtures.add_rows_success(rows)
   end
 
   def post("/sheets/" <> suffix, attributes, headers) do
     case String.split(suffix, "/") do
+      ["add_rows_fail_id", "rows"] ->
+        Smartsheet.MockClient.ResponseFixtures.add_rows_failure()
+
       [_id, "rows"] ->
         Smartsheet.MockClient.post("/sheets/:id/rows", attributes, headers)
 

--- a/lib/smartsheet/mock_client/response_fixtures.ex
+++ b/lib/smartsheet/mock_client/response_fixtures.ex
@@ -192,36 +192,17 @@ defmodule Smartsheet.MockClient.ResponseFixtures do
     })
   end
 
-  def add_rows_success() do
+  def add_rows_success(rows \\ []) do
+    result =
+      Enum.with_index(rows)
+      |> Enum.map(fn {row, index} ->
+        Map.put(row, :id, index)
+      end)
+
     format_response(%HTTPoison.Response{
       body: %{
         message: "SUCCESS",
-        result: [
-          %{
-            cells: [%{column_id: 7_136_425_824_020_356}, %{column_id: 1_506_926_289_807_236}],
-            created_at: "2020-07-22T21:26:48Z",
-            expanded: true,
-            id: 2_912_283_551_393_668,
-            locked: true,
-            locked_for_user: false,
-            modified_at: "2020-07-22T21:26:48Z",
-            row_number: 7,
-            sheet_id: 5_669_708_297_987_972,
-            sibling_id: 6_033_822_295_582_596
-          },
-          %{
-            cells: [%{column_id: 7_136_425_824_020_356}, %{column_id: 1_506_926_289_807_236}],
-            created_at: "2020-07-22T21:26:48Z",
-            expanded: true,
-            id: 7_415_883_178_764_164,
-            locked: true,
-            locked_for_user: false,
-            modified_at: "2020-07-22T21:26:48Z",
-            row_number: 8,
-            sheet_id: 5_669_708_297_987_972,
-            sibling_id: 2_912_283_551_393_668
-          }
-        ],
+        result: result,
         result_code: 0,
         version: 10
       },

--- a/lib/smartsheet/parse_response.ex
+++ b/lib/smartsheet/parse_response.ex
@@ -47,9 +47,15 @@ defmodule Smartsheet.ParseResponse do
   end
 
   defp parse_row(row_map) do
-    cells = parse_cells(row_map.cells)
-    row = %{row_map | cells: cells}
-    struct(Smartsheet.Row, row)
+    cond do
+      Map.has_key?(row_map, :cells) ->
+        cells = parse_cells(row_map.cells)
+        row = %{row_map | cells: cells}
+        struct(Smartsheet.Row, row)
+
+      true ->
+        struct(Smartsheet.Row, row_map)
+    end
   end
 
   defp parse_cells(cell_maps) do
@@ -57,9 +63,15 @@ defmodule Smartsheet.ParseResponse do
   end
 
   defp parse_sheet(sheet_map) do
-    columns = parse_columns(sheet_map.columns)
-    sheet = %{sheet_map | columns: columns}
-    struct(Smartsheet.Sheet, sheet)
+    cond do
+      Map.has_key?(sheet_map, :columns) ->
+        columns = parse_columns(sheet_map.columns)
+        sheet = %{sheet_map | columns: columns}
+        struct(Smartsheet.Sheet, sheet)
+
+      true ->
+        struct(Smartsheet.Sheet, sheet_map)
+    end
   end
 
   defp parse_columns(columns) do

--- a/test/smartsheet/parse_response_test.exs
+++ b/test/smartsheet/parse_response_test.exs
@@ -40,12 +40,13 @@ defmodule Smartsheet.ParseResponseTest do
 
   describe "Smartsheet.Rows" do
     test ":add_to_sheet success" do
-      {:ok, raw_http_response} = ResponseFixtures.add_rows_success()
+      {:ok, raw_http_response} = ResponseFixtures.add_rows_success([%{locked_for_user: false}])
 
       wrapped_response =
         ParseResponse.parse(Smartsheet.Rows, {:add_to_sheet, 1}, raw_http_response)
 
       assert {:ok, %Smartsheet.Response{}, rows} = wrapped_response
+
       first_row = List.first(rows)
       assert first_row.locked_for_user == false
 


### PR DESCRIPTION
Update MockClient to be able to pattern match on failed IDs to return mock failure responses.

Also updates ResponseFixtures for add_rows to be able to return the same amount of rows as was passed-in via attributes, so callers can pattern match on the response if necessary