### PR TITLE
bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The package can be installed by adding `smartsheet` to your list of dependencies
 ```elixir
 def deps do
   [
-    {:smartsheet, "~> 0.1.0"}
+    {:smartsheet, "~> 1.0.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Smartsheet.MixProject do
       app: :smartsheet,
       description: "HTTP wrapper around the Smartsheet API",
       package: package(),
-      version: "0.1.0",
+      version: "1.0.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
Originally i just took the default version i got when i generated the app. Gonna use semantic versioning from now on, starting with 1.0.0 which will be this version of the app