### PR TITLE
Add delete_rows functionality

### DIFF
--- a/lib/smartsheet/client_behaviour.ex
+++ b/lib/smartsheet/client_behaviour.ex
@@ -1,34 +1,11 @@
 defmodule Smartsheet.ClientBehaviour do
-  @callback get_sheet(String.t(), List) ::
-              {:ok, Smartsheet.Response.t(), Smartsheet.Sheet.t()}
-              | {:error, Smartsheet.Response.t()}
-
-  @callback create_sheet(map()) ::
-              {:ok, Smartsheet.Response.t(), Smartsheet.Sheet.t()}
-              | {:error, Smartsheet.Response.t()}
-              | {:internal_error, atom()}
-  @callback get_columns(String.t(), List) ::
-              {:ok, Smartsheet.Response.t(), [Smartsheet.Column]}
-              | {:error, Smartsheet.Response.t()}
-              | {:internal_error, atom()}
-
-  @callback add_rows(String.t(), any) ::
-              {:ok, Smartsheet.Response.t(), [Smartsheet.Row.t()]}
-              | {:error, Smartsheet.Response.t()}
-              | {:internal_error, atom()}
-
-  @callback update_rows(String.t(), any) ::
-              {:ok, Smartsheet.Response.t(), [Smartsheet.Row.t()]}
-              | {:error, Smartsheet.Response.t()}
-              | {:internal_error, atom()}
-
-  @callback get_row(String.t(), String.t()) ::
-              {:ok, Smartsheet.Response.t(), Smartsheet.Row.t()}
-              | {:error, Smartsheet.Response.t()}
-              | {:internal_error, atom()}
-
   @callback add_webhook(map()) ::
               {:ok, Smartsheet.Response.t(), Smartsheet.Webhook.t()}
+              | {:error, Smartsheet.Response.t()}
+              | {:internal_error, atom()}
+
+  @callback list_webhooks() ::
+              {:ok, Smartsheet.Response.t(), [Smartsheet.Webhook.t()]}
               | {:error, Smartsheet.Response.t()}
               | {:internal_error, atom()}
 
@@ -42,8 +19,37 @@ defmodule Smartsheet.ClientBehaviour do
               | {:error, Smartsheet.Response.t()}
               | {:internal_error, atom()}
 
-  @callback list_webhooks() ::
-              {:ok, Smartsheet.Response.t(), [Smartsheet.Webhook.t()]}
+  @callback create_sheet(map()) ::
+              {:ok, Smartsheet.Response.t(), Smartsheet.Sheet.t()}
+              | {:error, Smartsheet.Response.t()}
+              | {:internal_error, atom()}
+
+  @callback get_sheet(String.t(), List) ::
+              {:ok, Smartsheet.Response.t(), Smartsheet.Sheet.t()}
+              | {:error, Smartsheet.Response.t()}
+
+  @callback get_columns(String.t(), List) ::
+              {:ok, Smartsheet.Response.t(), [Smartsheet.Column]}
+              | {:error, Smartsheet.Response.t()}
+              | {:internal_error, atom()}
+
+  @callback add_rows(String.t(), any) ::
+              {:ok, Smartsheet.Response.t(), [Smartsheet.Row.t()]}
+              | {:error, Smartsheet.Response.t()}
+              | {:internal_error, atom()}
+
+  @callback get_row(String.t(), String.t()) ::
+              {:ok, Smartsheet.Response.t(), Smartsheet.Row.t()}
+              | {:error, Smartsheet.Response.t()}
+              | {:internal_error, atom()}
+
+  @callback update_rows(String.t(), any) ::
+              {:ok, Smartsheet.Response.t(), [Smartsheet.Row.t()]}
+              | {:error, Smartsheet.Response.t()}
+              | {:internal_error, atom()}
+
+  @callback delete_rows(String.t(), List) ::
+              {:ok, Smartsheet.Response.t(), map()}
               | {:error, Smartsheet.Response.t()}
               | {:internal_error, atom()}
 end

--- a/lib/smartsheet/parse_response.ex
+++ b/lib/smartsheet/parse_response.ex
@@ -95,6 +95,16 @@ defmodule Smartsheet.ParseResponse do
     end
   end
 
+  def parse({:delete_rows, _arity}, response = %HTTPoison.Response{}) do
+    case response.status_code do
+      200 ->
+        success_response(response, %{})
+
+      _ ->
+        error_response(response)
+    end
+  end
+
   def parse({:get_row, _arity}, response = %HTTPoison.Response{}) do
     case response.status_code do
       200 ->

--- a/lib/smartsheet/response_fixtures.ex
+++ b/lib/smartsheet/response_fixtures.ex
@@ -411,6 +411,69 @@ defmodule Smartsheet.MockClient.ResponseFixtures do
     })
   end
 
+  def delete_rows_success() do
+    format_response(%HTTPoison.Response{
+      body: %{
+        message: "SUCCESS",
+        result: [1_936_303_049_467_780, 4_220_888_496_007_044],
+        result_code: 0
+      },
+      headers: [
+        {"Date", "Wed, 21 Oct 2020 19:58:01 GMT"},
+        {"Content-Type", "application/json;charset=UTF-8"},
+        {"Content-Length", "81"},
+        {"Connection", "keep-alive"},
+        {"Cache-Control", "no-cache, no-store, must-revalidate"},
+        {"Pragma", "no-cache"},
+        {"Expires", "0"},
+        {"Vary", "Accept-Encoding"}
+      ],
+      request: %HTTPoison.Request{
+        body: "\"\"",
+        headers: [Authorization: "Bearer 123"],
+        method: :delete,
+        options: [
+          recv_timeout: 5000,
+          params: [ids: "1936303049467780,4220888496007044"]
+        ],
+        params: [ids: "1936303049467780,4220888496007044"],
+        url:
+          "https://api.smartsheet.com/2.0/sheets/3944882986346372/rows?ids=1936303049467780%2C4220888496007044"
+      },
+      request_url:
+        "https://api.smartsheet.com/2.0/sheets/3944882986346372/rows?ids=1936303049467780%2C4220888496007044",
+      status_code: 200
+    })
+  end
+
+  def delete_rows_failure() do
+    format_response(%HTTPoison.Response{
+      body: %{
+        detail: %{ids: '{', type: "row"},
+        error_code: 1006,
+        message: "Not Found",
+        ref_id: "x1y909cyw3f2"
+      },
+      headers: [
+        {"Date", "Wed, 21 Oct 2020 20:03:07 GMT"},
+        {"Content-Type", "application/json;charset=UTF-8"},
+        {"Content-Length", "139"},
+        {"Connection", "keep-alive"},
+        {"Vary", "Accept-Encoding"}
+      ],
+      request: %HTTPoison.Request{
+        body: "\"\"",
+        headers: [Authorization: "123"],
+        method: :delete,
+        options: [recv_timeout: 5000, params: [ids: "123"]],
+        params: [ids: "123"],
+        url: "https://api.smartsheet.com/2.0/sheets/3944882986346372/rows?ids=123"
+      },
+      request_url: "https://api.smartsheet.com/2.0/sheets/3944882986346372/rows?ids=123",
+      status_code: 404
+    })
+  end
+
   def get_row_failure() do
     format_response(%HTTPoison.Response{
       body: %{

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Smartsheet.MixProject do
       app: :smartsheet,
       description: "HTTP wrapper around the Smartsheet API",
       package: package(),
-      version: "2.3.1",
+      version: "2.4.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/test/smartsheet/parse_response_test.exs
+++ b/test/smartsheet/parse_response_test.exs
@@ -102,6 +102,20 @@ defmodule Smartsheet.ParseResponseTest do
     end
   end
 
+  describe ":delete_rows" do
+    test "success" do
+      {:ok, raw_http_response} = ResponseFixtures.delete_rows_success()
+      wrapped_response = ParseResponse.parse({:delete_rows, 1}, raw_http_response)
+      assert {:ok, %Smartsheet.Response{}, %{}} = wrapped_response
+    end
+
+    test "failure" do
+      {:ok, raw_http_response} = ResponseFixtures.delete_rows_failure()
+      wrapped_response = ParseResponse.parse({:delete_rows, 1}, raw_http_response)
+      assert {:error, %Smartsheet.Response{status_code: 404}} = wrapped_response
+    end
+  end
+
   describe ":get_row" do
     test "success" do
       {:ok, raw_http_response} = ResponseFixtures.get_row_success()


### PR DESCRIPTION
I just finished the work to soft-delete order line items. When they are deleted, we're gonna want to delete their corresponding rows in Smartsheets.

This PR also:
1. Ups the response timeout via a config variable
2. Refactors some of the duplication in the client