### PR TITLE
Set response timeout to also be a function

### DIFF
--- a/lib/smartsheet/http_client.ex
+++ b/lib/smartsheet/http_client.ex
@@ -115,10 +115,9 @@ defmodule Smartsheet.HttpClient do
     [{:Authorization, "Bearer #{api_key()}"} | headers]
   end
 
-  @response_timeout Application.get_env(:smartsheet, :response_timeout) || 5000
   @impl HTTPoison.Base
   def process_request_options(options) do
-    [{:recv_timeout, @response_timeout} | options]
+    [{:recv_timeout, response_timeout()} | options]
   end
 
   @impl HTTPoison.Base
@@ -131,5 +130,9 @@ defmodule Smartsheet.HttpClient do
 
   defp api_key() do
     Application.get_env(:smartsheet, :api_key) || System.get_env("SMARTSHEET_API_KEY")
+  end
+
+  defp response_timeout() do
+    Application.get_env(:smartsheet, :response_timeout) || 5000
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Smartsheet.MixProject do
       app: :smartsheet,
       description: "HTTP wrapper around the Smartsheet API",
       package: package(),
-      version: "2.5.0",
+      version: "2.5.1",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
so that it is not only evaluated at compile time. I did this yesterday for the `api_key` and somehow didn't realize that it should also be done for the response_timeout.